### PR TITLE
Enable bilingual Polish/English support

### DIFF
--- a/src/context/LanguageContext.jsx
+++ b/src/context/LanguageContext.jsx
@@ -1,0 +1,15 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const LanguageContext = createContext();
+
+export const LanguageProvider = ({ children }) => {
+  const [language, setLanguage] = useState('pl');
+  const changeLanguage = (lang) => setLanguage(lang);
+  return (
+    <LanguageContext.Provider value={{ language, changeLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+export const useLanguage = () => useContext(LanguageContext);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,12 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import { BrowserRouter } from 'react-router-dom';
+import { LanguageProvider } from './context/LanguageContext';
 import './global.css' 
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <LanguageProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </LanguageProvider>
   </React.StrictMode>
 );

--- a/src/pages/AdminPanel.jsx
+++ b/src/pages/AdminPanel.jsx
@@ -22,12 +22,14 @@ const AdminPanel = () => {
 
   const [newItem, setNewItem] = useState({
     id: null,
-    title: "",
+    titlePl: "",
+    titleEn: "",
     category: "trucks",
     type: "sale",
     year: "",
     status: "available",
-    description: "",
+    descriptionPl: "",
+    descriptionEn: "",
     specs: [],
     images: [],
     mainImage: "",
@@ -173,12 +175,14 @@ const AdminPanel = () => {
   const resetForm = () => {
     setNewItem({
       id: null,
-      title: "",
+      titlePl: "",
+      titleEn: "",
       category: "trucks",
       type: selectedTab,
       year: "",
       status: selectedTab === "sale" ? "available" : "poszukiwane",
-      description: "",
+      descriptionPl: "",
+      descriptionEn: "",
       specs: [],
       images: [],
       mainImage: "",

--- a/src/pages/ItemPage.jsx
+++ b/src/pages/ItemPage.jsx
@@ -35,14 +35,18 @@ const ItemPage = () => {
   }
 
   const {
+      titlePl,
+      titleEn,
       title,
       mainImage,
       image,
       specs,
+      descriptionPl,
+      descriptionEn,
       description,
       type,
       category,
-      images, // в будущем — массив фото
+      images,
     } = currentItem;
 
   return (
@@ -51,9 +55,13 @@ const ItemPage = () => {
       <main style={{ maxWidth: "80rem", margin: "0 auto", padding: "6rem 1.5rem 2rem" }}>
 
       <ItemHeader
+          titlePl={titlePl}
+          titleEn={titleEn}
           title={title}
           mainImage={mainImage}
           specs={specs}
+          descriptionPl={descriptionPl}
+          descriptionEn={descriptionEn}
           description={description}
         />
         <ItemGallery images={images && images.length > 0 ? images : [mainImage || image]} />

--- a/src/pages/PurchaseItemPage.jsx
+++ b/src/pages/PurchaseItemPage.jsx
@@ -32,17 +32,20 @@ const PurchaseItemPage = () => {
     );
   }
 
-  const { title, mainImage, specs, description, type, category } = currentItem;
+  const { titlePl, titleEn, title, mainImage, specs, descriptionPl, descriptionEn, type, category } = currentItem;
 
   return (
     <>
       <Navbar />
       <main style={{ maxWidth: "80rem", margin: "0 auto", padding: "6rem 1.5rem 2rem" }}>
         <PurchaseItemHeader
+          titlePl={titlePl}
+          titleEn={titleEn}
           title={title}
           mainImage={mainImage}
           specs={specs}
-          description={description}
+          descriptionPl={descriptionPl}
+          descriptionEn={descriptionEn}
         />
 
         <ItemContactForm />

--- a/src/pages/PurchasePage.jsx
+++ b/src/pages/PurchasePage.jsx
@@ -5,6 +5,7 @@ import FilterPurchase from "../sections/PurchasePage/FilterPurchase";
 import PurchaseItemArea from "../sections/PurchasePage/PurchaseItemArea";
 import styles from "./SalePage.module.css"; // можно переименовать позже в shared style
 import { fetchItems } from "../utils/firestoreItems";
+import { useLanguage } from "../context/LanguageContext";
 
 const getItemsPerPage = () => {
   if (window.innerWidth <= 768) return 6;
@@ -12,6 +13,7 @@ const getItemsPerPage = () => {
 };
 
 const PurchasePage = () => {
+  const { language } = useLanguage();
   const [selectedCategory, setSelectedCategory] = useState("all");
   const [currentPage, setCurrentPage] = useState(1);
   const [items, setItems] = useState([]);
@@ -53,7 +55,9 @@ const PurchasePage = () => {
 
       <main className={styles.wrapper}>
         <section className={styles.container}>
-          <h1 className={styles.heading}>Zapotrzebowania zakupowe</h1>
+          <h1 className={styles.heading}>
+            {language === "pl" ? "Zapotrzebowania zakupowe" : "Purchase demands"}
+          </h1>
         </section>
 
         <FilterPurchase selected={selectedCategory} onSelect={setSelectedCategory} />

--- a/src/pages/SalePage.jsx
+++ b/src/pages/SalePage.jsx
@@ -5,10 +5,12 @@ import FilterSale from "../sections/SalePage/FilterSale";
 import ItemArea from "../sections/SalePage/ItemArea";
 import styles from "./SalePage.module.css";
 import { fetchItems } from "../utils/firestoreItems";
+import { useLanguage } from "../context/LanguageContext";
 
 
 
 const SalePage = () => {
+  const { language } = useLanguage();
   const [items, setItems] = useState([]);
   const [filtered, setFiltered] = useState([]);
   const [activeCategory, setActiveCategory] = useState("all");
@@ -66,7 +68,9 @@ useEffect(() => {
 
       <main className={styles.wrapper}>
         <section className={styles.container}>
-          <h1 className={styles.heading}>Nasze ogłoszenia</h1>
+          <h1 className={styles.heading}>
+            {language === "pl" ? "Nasze ogłoszenia" : "Our offers"}
+          </h1>
         </section>
 
         <FilterSale active={activeCategory} setActive={setActiveCategory} />

--- a/src/sections/AdminPanel/AdminFormPurchase.jsx
+++ b/src/sections/AdminPanel/AdminFormPurchase.jsx
@@ -55,11 +55,17 @@ const AdminFormPurchase = ({
       </h3>
 
       <input
-        name="title"
-        placeholder="Tytuł"
-        value={newItem.title}
+        name="titlePl"
+        placeholder="Tytuł (PL)"
+        value={newItem.titlePl}
         onChange={onChange}
         required
+      />
+      <input
+        name="titleEn"
+        placeholder="Title (EN)"
+        value={newItem.titleEn}
+        onChange={onChange}
       />
       <input
         name="year"
@@ -79,9 +85,15 @@ const AdminFormPurchase = ({
       )}
 
       <textarea
-        name="description"
-        placeholder="Opis"
-        value={newItem.description}
+        name="descriptionPl"
+        placeholder="Opis (PL)"
+        value={newItem.descriptionPl}
+        onChange={onChange}
+      />
+      <textarea
+        name="descriptionEn"
+        placeholder="Description (EN)"
+        value={newItem.descriptionEn}
         onChange={onChange}
       />
 

--- a/src/sections/AdminPanel/AdminFormSale.jsx
+++ b/src/sections/AdminPanel/AdminFormSale.jsx
@@ -84,11 +84,17 @@ const AdminFormSale = ({
       </h3>
 
       <input
-        name="title"
-        placeholder="Tytuł"
-        value={newItem.title}
+        name="titlePl"
+        placeholder="Tytuł (PL)"
+        value={newItem.titlePl}
         onChange={onChange}
         required
+      />
+      <input
+        name="titleEn"
+        placeholder="Title (EN)"
+        value={newItem.titleEn}
+        onChange={onChange}
       />
       <input
         name="year"
@@ -108,9 +114,15 @@ const AdminFormSale = ({
       )}
 
       <textarea
-        name="description"
-        placeholder="Opis"
-        value={newItem.description}
+        name="descriptionPl"
+        placeholder="Opis (PL)"
+        value={newItem.descriptionPl}
+        onChange={onChange}
+      />
+      <textarea
+        name="descriptionEn"
+        placeholder="Description (EN)"
+        value={newItem.descriptionEn}
         onChange={onChange}
       />
 

--- a/src/sections/AdminPanel/AdminItemList.jsx
+++ b/src/sections/AdminPanel/AdminItemList.jsx
@@ -21,7 +21,7 @@ const AdminItemList = ({ items, onEdit, onDelete }) => {
             <tbody>
               {items.map((item) => (
                 <tr key={item.id}>
-                  <td>{item.title}</td>
+                  <td>{item.titlePl || item.titleEn || item.title}</td>
                   <td>{item.category}</td>
                   <td>{item.year}</td>
                   <td>{item.status.toUpperCase()}</td>

--- a/src/sections/ItemPage/ItemContactForm.jsx
+++ b/src/sections/ItemPage/ItemContactForm.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import styles from "./ItemContactForm.module.css";
+import { useLanguage } from "../../context/LanguageContext";
 
 import CallIcon from "../../assets/icons/CallIcon.svg";
 import OfficeCallIcon from "../../assets/icons/OffieCallIcon.svg";
@@ -8,7 +9,13 @@ import FacebookIcon from "../../assets/images/MainPage/socialmeia/FacebookIcon.p
 import InstagramIcon from "../../assets/images/MainPage/socialmeia/InstagramIcon.png";
 import MessengerIcon from "../../assets/images/MainPage/socialmeia/MassengerIcon.png";
 
+const texts = {
+  pl: { heading: "Kontakt w sprawie oferty", name: "Imię", email: "Email", msg: "Wiadomość", send: "Wyślij", success: "Wiadomość wysłana!" },
+  en: { heading: "Contact to verify", name: "Your Name", email: "Your Email", msg: "Your Message", send: "Send", success: "Message sent successfully!" },
+};
+
 const ItemContactForm = () => {
+  const { language } = useLanguage();
   const [formData, setFormData] = useState({
     name: "",
     email: "",
@@ -34,7 +41,7 @@ const ItemContactForm = () => {
         <div className={styles.content}>
           {/* Левая колонка — контакты */}
           <div className={styles.left}>
-            <h2 className={styles.heading}>Contact to verify</h2>
+            <h2 className={styles.heading}>{texts[language].heading}</h2>
 
             <ul className={styles.infoList}>
               <li>
@@ -69,7 +76,7 @@ const ItemContactForm = () => {
             <input
               type="text"
               name="name"
-              placeholder="Your Name"
+              placeholder={texts[language].name}
               value={formData.name}
               onChange={handleChange}
               required
@@ -78,7 +85,7 @@ const ItemContactForm = () => {
             <input
               type="email"
               name="email"
-              placeholder="Your Email"
+              placeholder={texts[language].email}
               value={formData.email}
               onChange={handleChange}
               required
@@ -86,15 +93,15 @@ const ItemContactForm = () => {
             />
             <textarea
               name="message"
-              placeholder="Your Message"
+              placeholder={texts[language].msg}
               rows="5"
               value={formData.message}
               onChange={handleChange}
               required
               className={styles.textarea}
             />
-            <button type="submit" className={styles.button}>Send</button>
-            {sent && <p className={styles.success}>Message sent successfully!</p>}
+            <button type="submit" className={styles.button}>{texts[language].send}</button>
+            {sent && <p className={styles.success}>{texts[language].success}</p>}
           </form>
         </div>
       </div>

--- a/src/sections/ItemPage/ItemHeader.jsx
+++ b/src/sections/ItemPage/ItemHeader.jsx
@@ -1,11 +1,13 @@
 import React from "react";
 import styles from "./ItemHeader.module.css";
+import { useLanguage } from "../../context/LanguageContext";
 
-const ItemHeader = ({ title, mainImage, specs, description }) => {
+const ItemHeader = ({ titlePl, titleEn, title, mainImage, specs, descriptionPl, descriptionEn }) => {
+  const { language } = useLanguage();
   return (
     <section className={styles.wrapper}>
       <div className={styles.container}>
-        <h1 className={styles.title}>{title}</h1>
+        <h1 className={styles.title}>{language === 'pl' ? (titlePl || title) : (titleEn || title)}</h1>
         <div className={styles.content}>
           <div className={styles.imageBlock}>
             <img src={mainImage} alt={title} />
@@ -23,8 +25,10 @@ const ItemHeader = ({ title, mainImage, specs, description }) => {
               </tbody>
             </table>
 
-            <h3 className={styles.descTitle}>Description</h3>
-            <p className={styles.description}>{description}</p>
+            <h3 className={styles.descTitle}>{language === 'pl' ? 'Opis' : 'Description'}</h3>
+            <p className={styles.description}>
+              {language === 'pl' ? (descriptionPl || descriptionEn) : (descriptionEn || descriptionPl)}
+            </p>
           </div>
         </div>
       </div>

--- a/src/sections/MainPage/AboutUsSection.jsx
+++ b/src/sections/MainPage/AboutUsSection.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import styles from "./AboutUsSection.module.css";
 import { useInView } from "../../hooks/useInView";
+import { useLanguage } from "../../context/LanguageContext";
 
 const AnimatedNumber = ({ target, duration = 1000 }) => {
   const [value, setValue] = useState(0);
@@ -26,7 +27,27 @@ const AnimatedNumber = ({ target, duration = 1000 }) => {
   return <h3>{value}+</h3>;
 };
 
+const texts = {
+  pl: {
+    title: "O nas",
+    desc:
+      "Jesteśmy międzynarodową firmą motoryzacyjną. Eksportujemy, importujemy, kupujemy i sprzedajemy nowe i używane silniki, ciężarówki, pojazdy dostawcze, ciągniki, wywrotki, samochody osobowe, autobusy, naczepy, chłodnie, maszyny budowlane i rolnicze oraz ich części.",
+    years: "lat\ndoświadczenia",
+    clients: "zadowolonych klientów",
+    countries: "obsługiwanych\nkrajów",
+  },
+  en: {
+    title: "About Us",
+    desc:
+      "We are an international automotive company, exporting, importing, purchasing and selling new and used engines, trucks, delivery trucks, truck heads, tippers, passenger cars, buses, semitrailers, refrigerated trucks, building machines, industrial and agricultural machines and their parts.",
+    years: "Years of\nexperience",
+    clients: "satisfied clients",
+    countries: "countries\nserved",
+  },
+};
+
 const AboutUsSection = () => {
+  const { language } = useLanguage();
   const [ref, isVisible] = useInView(0.2);
 
   return (
@@ -34,23 +55,21 @@ const AboutUsSection = () => {
       <div className={styles.container}>
         <div className={styles.aboutRow}>
           <div className={styles.aboutText}>
-            <h2>About Us</h2>
-            <p>
-              We are an international automotive company, we export, import, purchase and sell new and used engines, trucks, delivery trucks, trucks heads, tippers, passenger cars, buses, semitrailers, refrigerated trucks, building machines, industrial and agricultural machines and their parts.
-            </p>
+            <h2>{texts[language].title}</h2>
+            <p>{texts[language].desc}</p>
           </div>
           <div className={styles.stats}>
             <div>
               {isVisible && <AnimatedNumber target={15} />}
-              <p>Years of<br />experience</p>
+              <p>{texts[language].years}</p>
             </div>
             <div>
               {isVisible && <AnimatedNumber target={1000} />}
-              <p>satisfied clients</p>
+              <p>{texts[language].clients}</p>
             </div>
             <div>
               {isVisible && <AnimatedNumber target={30} />}
-              <p>countries<br />served</p>
+              <p>{texts[language].countries}</p>
             </div>
           </div>
         </div>

--- a/src/sections/MainPage/ContactSection.jsx
+++ b/src/sections/MainPage/ContactSection.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import styles from "./ContactSection.module.css";
 import background from "../../assets/images/MainPage/ContactBackImage.png";
 import { useInView } from "../../hooks/useInView";
+import { useLanguage } from "../../context/LanguageContext";
 
 import CallIcon from "../../assets/icons/CallIcon.svg";
 import OfficeCallIcon from "../../assets/icons/OffieCallIcon.svg";
@@ -11,7 +12,25 @@ import FacebookIcon from "../../assets/images/MainPage/socialmeia/FacebookIcon.p
 import InstagramIcon from "../../assets/images/MainPage/socialmeia/InstagramIcon.png";
 import MessengerIcon from "../../assets/images/MainPage/socialmeia/MassengerIcon.png";
 
+const texts = {
+  pl: {
+    heading: "Skontaktuj się, aby uzyskać informacje",
+    name: "Imię",
+    email: "Email",
+    msg: "Wiadomość",
+    send: "Wyślij",
+  },
+  en: {
+    heading: "Contact to verify",
+    name: "Name",
+    email: "Email",
+    msg: "Message",
+    send: "Send",
+  },
+};
+
 const ContactSection = () => {
+  const { language } = useLanguage();
   const [ref, isVisible] = useInView(0.25);
 
   return (
@@ -25,7 +44,7 @@ const ContactSection = () => {
         <div className={styles.content}>
           <div className={styles.left}>
             <div>
-              <h2 className={styles.heading}>Contact to verify</h2>
+              <h2 className={styles.heading}>{texts[language].heading}</h2>
               <ul className={styles.infoList}>
                 <li>
                   <img src={CallIcon} alt="Phone" className={styles.icon} />
@@ -76,10 +95,10 @@ const ContactSection = () => {
               console.log("Sending form...");
             }}
           >
-            <input type="text" placeholder="Name" className={styles.input} required />
-            <input type="email" placeholder="Email" className={styles.input} required />
-            <textarea placeholder="Message" className={styles.textarea} required></textarea>
-            <button type="submit" className={styles.button}>Send</button>
+            <input type="text" placeholder={texts[language].name} className={styles.input} required />
+            <input type="email" placeholder={texts[language].email} className={styles.input} required />
+            <textarea placeholder={texts[language].msg} className={styles.textarea} required></textarea>
+            <button type="submit" className={styles.button}>{texts[language].send}</button>
           </form>
         </div>
       </div>

--- a/src/sections/MainPage/Footer.jsx
+++ b/src/sections/MainPage/Footer.jsx
@@ -1,15 +1,22 @@
 import React from "react";
 import styles from "./Footer.module.css";
 import logo from "../../assets/images/logo.png";
+import { useLanguage } from "../../context/LanguageContext";
+
+const texts = {
+  pl: "Wszelkie prawa zastrzeżone.",
+  en: "All rights reserved.",
+};
 
 const Footer = () => {
+  const { language } = useLanguage();
   return (
     <footer className={styles.footer}>
       <div className={styles.container}>
         <img src={logo} alt="KrakTruck Logo" className={styles.logo} />
         <p className={styles.text}>
           Copyright (c) 2023&nbsp;
-          <a href="https://kraktruck.pl" className={styles.link}>kraktruck.pl</a>. All rights reserved.
+          <a href="https://kraktruck.pl" className={styles.link}>kraktruck.pl</a>. {texts[language]}
         </p>
       </div>
     </footer>

--- a/src/sections/MainPage/HeroSection.jsx
+++ b/src/sections/MainPage/HeroSection.jsx
@@ -2,8 +2,39 @@ import React, { useEffect, useState } from "react";
 import styles from "./HeroSection.module.css";
 import TruckBackground from "../../assets/videos/TruckBackground.webm";
 import { scrollToSection } from "../../hooks/scrollToSection";
+import { useLanguage } from "../../context/LanguageContext";
 
-const phrasesPL = [
+const phrases = {
+  pl: [
+    "AUTA CIĘŻAROWE – Skup i sprzedaż aut ciężarowych, ciągników siodłowych",
+    "AUTA OSOBOWE – Skup i sprzedaż aut osobowych i dostawczych",
+    "SILNIKI I CZĘŚCI – Skup i sprzedaż silników i części do wszystkich typów pojazdów",
+    "MASZYNY BUDOWLANE – Skup i sprzedaż maszyn przemysłowych i rolniczych",
+    "AUTOBUSY – Skup i sprzedaż autokarów, autobusów i busów",
+    "NACZEPY – Skup i sprzedaż firanek, chłodni, cystern i innych",
+    "OPONY I FELGI – Skup i sprzedaż opon, felg, dętek i ochraniaczy",
+    "DEMONTAŻ I ZAŁADUNEK – Profesjonalny demontaż i załadunek pojazdów",
+    "TRANSPORT – Organizacja transportu krajowego i międzynarodowego",
+  ],
+  en: [
+    "TRUCKS – Purchase and sale of trucks and tractors",
+    "CARS – Purchase and sale of cars and vans",
+    "ENGINES & PARTS – Buying and selling engines and parts for all vehicles",
+    "CONSTRUCTION MACHINERY – Industrial and agricultural machines",
+    "BUSES – Purchase and sale of coaches and buses",
+    "TRAILERS – Curtainsiders, refrigerators, tanks and more",
+    "TIRES & RIMS – Sale of tires, rims and tubes",
+    "DISMANTLING & LOADING – Professional dismantling and loading",
+    "TRANSPORT – Domestic and international transport organization",
+  ],
+};
+
+const titles = {
+  pl: "Niezawodne rozwiązania\nw świecie ciężarówek",
+  en: "Reliable Solution\nin the World of\nTrucks",
+};
+
+const buttons = { pl: "Dowiedz się więcej", en: "Learn More" };
   "AUTA CIĘŻAROWE – Skup i sprzedaż aut ciężarowych, ciągników siodłowych",
   "AUTA OSOBOWE – Skup i sprzedaż aut osobowych i dostawczych",
   "SILNIKI I CZĘŚCI – Skup i sprzedaż silników i części do wszystkich typów pojazdów",
@@ -16,14 +47,15 @@ const phrasesPL = [
 ];
 
 const HeroSection = ({ scrollTarget }) => {
+  const { language } = useLanguage();
   const [currentIndex, setCurrentIndex] = useState(0);
 
   useEffect(() => {
     const interval = setInterval(() => {
-      setCurrentIndex((prev) => (prev + 1) % phrasesPL.length);
+      setCurrentIndex((prev) => (prev + 1) % phrases[language].length);
     }, 3500);
     return () => clearInterval(interval);
-  }, []);
+  }, [language]);
 
   const handleClick = () => {
     if (scrollTarget) scrollToSection(scrollTarget, 0.1);
@@ -40,15 +72,15 @@ const HeroSection = ({ scrollTarget }) => {
         <div className={styles.heroContainer}>
           <div className={styles.textBlock}>
             <h1 className={styles.title}>
-              Reliable Solution<br />in the World of<br />Trucks
+              {titles[language]}
             </h1>
 
             <div className={styles.phraseBox}>
               <p className={`${styles.phrase} ${styles.fade}`} key={currentIndex}>
-                {phrasesPL[currentIndex]}
+                {phrases[language][currentIndex]}
               </p>
               <button className={styles.cta} onClick={handleClick}>
-                Learn More
+                {buttons[language]}
               </button>
             </div>
           </div>

--- a/src/sections/MainPage/Navbar.jsx
+++ b/src/sections/MainPage/Navbar.jsx
@@ -5,17 +5,41 @@ import { useInView } from "../../hooks/useInView";
 import { scrollToSection } from "../../hooks/scrollToSection";
 import { Link } from "react-router-dom";
 import { GiHamburgerMenu } from "react-icons/gi";
+import { useLanguage } from "../../context/LanguageContext";
+
+const texts = {
+  pl: {
+    about: "O nas",
+    service: "Usługi",
+    purchase: "Zakup",
+    sale: "Sprzedaż",
+    contact: "Kontakt",
+    code: "PL",
+    en: "Angielski",
+    pl: "Polski",
+  },
+  en: {
+    about: "About us",
+    service: "Service",
+    purchase: "Purchase",
+    sale: "Sale",
+    contact: "Contact",
+    code: "EN",
+    en: "English",
+    pl: "Polski",
+  },
+};
 
 const Navbar = ({ refs }) => {
   const [ref, isVisible] = useInView(0.1);
   const [langMenuOpen, setLangMenuOpen] = useState(false);
-  const [language, setLanguage] = useState("EN");
+  const { language, changeLanguage } = useLanguage();
   const [menuOpen, setMenuOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(window.innerWidth <= 768);
 
   const toggleLangMenu = () => setLangMenuOpen(!langMenuOpen);
-  const changeLang = (lang) => {
-    setLanguage(lang);
+  const selectLang = (lang) => {
+    changeLanguage(lang);
     setLangMenuOpen(false);
   };
 
@@ -50,12 +74,12 @@ const Navbar = ({ refs }) => {
           <div className={styles.mobileControls}>
             <div className={styles.langWrapper}>
               <button onClick={toggleLangMenu} className={styles.langButton}>
-                {language}
+                {texts[language].code}
               </button>
               {langMenuOpen && (
                 <div className={styles.langDropdown}>
-                  <span onClick={() => changeLang("EN")}>English</span>
-                  <span onClick={() => changeLang("PL")}>Polski</span>
+                  <span onClick={() => selectLang("en")}>{texts.en.en}</span>
+                  <span onClick={() => selectLang("pl")}>{texts.pl.pl}</span>
                 </div>
               )}
             </div>
@@ -66,23 +90,23 @@ const Navbar = ({ refs }) => {
           </div>
         ) : (
           <ul className={styles.navLinks}>
-            <li className={styles.linkItem} onClick={() => handleScroll("about")}>About us</li>
-            <li className={styles.linkItem} onClick={() => handleScroll("service")}>Service</li>
+            <li className={styles.linkItem} onClick={() => handleScroll("about")}>{texts[language].about}</li>
+            <li className={styles.linkItem} onClick={() => handleScroll("service")}>{texts[language].service}</li>
             <li className={styles.linkItem}>
-              <Link to="/purchase" className={styles.navLink}>Purchase</Link>
+              <Link to="/purchase" className={styles.navLink}>{texts[language].purchase}</Link>
             </li>
             <li className={styles.linkItem}>
-              <Link to="/sale" className={styles.navLink}>Sale</Link>
+              <Link to="/sale" className={styles.navLink}>{texts[language].sale}</Link>
             </li>
             <li>
-              <button className={styles.contactButton} onClick={() => handleScroll("contact")}>Contact</button>
+              <button className={styles.contactButton} onClick={() => handleScroll("contact")}>{texts[language].contact}</button>
             </li>
             <li className={styles.langWrapper}>
-              <button onClick={toggleLangMenu} className={styles.langButton}>{language}</button>
+              <button onClick={toggleLangMenu} className={styles.langButton}>{texts[language].code}</button>
               {langMenuOpen && (
                 <div className={styles.langDropdown}>
-                  <span onClick={() => changeLang("EN")}>English</span>
-                  <span onClick={() => changeLang("PL")}>Polski</span>
+                  <span onClick={() => selectLang("en")}>{texts.en.en}</span>
+                  <span onClick={() => selectLang("pl")}>{texts.pl.pl}</span>
                 </div>
               )}
             </li>
@@ -92,13 +116,13 @@ const Navbar = ({ refs }) => {
         {isMobile && (
           <div className={`${styles.mobileMenu} ${menuOpen ? styles.open : ""}`}>
             <ul className={styles.mobileMenuList}>
-              <li onClick={() => handleScroll("about")}>About us</li>
-              <li onClick={() => handleScroll("service")}>Service</li>
-              <li><Link to="/purchase" onClick={() => setMenuOpen(false)}>Purchase</Link></li>
-              <li><Link to="/sale" onClick={() => setMenuOpen(false)}>Sale</Link></li>
+              <li onClick={() => handleScroll("about")}>{texts[language].about}</li>
+              <li onClick={() => handleScroll("service")}>{texts[language].service}</li>
+              <li><Link to="/purchase" onClick={() => setMenuOpen(false)}>{texts[language].purchase}</Link></li>
+              <li><Link to="/sale" onClick={() => setMenuOpen(false)}>{texts[language].sale}</Link></li>
               <li>
                 <button onClick={() => handleScroll("contact")} className={styles.contactButton}>
-                  Contact
+                  {texts[language].contact}
                 </button>
               </li>
             </ul>

--- a/src/sections/MainPage/OurActivitySection.jsx
+++ b/src/sections/MainPage/OurActivitySection.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styles from "./OurActivitySection.module.css";
 import { useInView } from "../../hooks/useInView";
+import { useLanguage } from "../../context/LanguageContext";
 
 import Audi from "../../assets/images/MainPage/logos/Audi.png";
 import BMW from "../../assets/images/MainPage/logos/BMW.png";
@@ -32,7 +33,19 @@ const logos = [
   KOMATSU, VolksWagen, SCHMITZ, JCB, VOGELE, MAN
 ];
 
+const texts = {
+  pl: {
+    title: "Nasza działalność",
+    desc: "Zajmujemy się szeroką gamą pojazdów i sprzętu, koncentrując się na następujących markach:",
+  },
+  en: {
+    title: "Our Activity",
+    desc: "We deal with a wide variety of vehicles and equipment, with a focus on the following brands:",
+  },
+};
+
 const OurActivitySection = () => {
+  const { language } = useLanguage();
   const [ref, isVisible] = useInView(0.3);
 
   return (
@@ -45,10 +58,8 @@ const OurActivitySection = () => {
       }}
     >
       <div className={styles.container}>
-        <h2 className={styles.title}>Our Activity</h2>
-        <p className={styles.description}>
-          We deal with a wide variety of vehicles and equipment, with a focus on the following brands:
-        </p>
+        <h2 className={styles.title}>{texts[language].title}</h2>
+        <p className={styles.description}>{texts[language].desc}</p>
         <div className={styles.logoGrid}>
           {logos.map((logo, index) => (
             <img

--- a/src/sections/MainPage/OurServiceSection.jsx
+++ b/src/sections/MainPage/OurServiceSection.jsx
@@ -1,13 +1,32 @@
 import React from "react";
 import styles from "./OurServiceSection.module.css";
 import { useInView } from "../../hooks/useInView";
+import { useLanguage } from "../../context/LanguageContext";
 
 import TruckSalesIcon from "../../assets/images/MainPage/icons/TrukSales.png";
 import ImportExportIcon from "../../assets/images/MainPage/icons/ImportExport.png";
 import UsedTruckIcon from "../../assets/images/MainPage/icons/UsedTrucks.png";
 import SparePartsIcon from "../../assets/images/MainPage/icons/SparePartsEngines.png";
 
+const texts = {
+  pl: {
+    title: "Nasze usługi",
+    sales: "Sprzedaż ciężarówek",
+    importExport: "Import/Export",
+    used: "Skup używanych\npojazdów",
+    parts: "Części zamienne\n& Silniki",
+  },
+  en: {
+    title: "Our Services",
+    sales: "Truck Sales",
+    importExport: "Import/Export",
+    used: "Used Truck\nPurchase",
+    parts: "Spare Parts\n& Engine",
+  },
+};
+
 const OurServiceSection = () => {
+  const { language } = useLanguage();
   const [ref, isVisible] = useInView(0.2);
 
   return (
@@ -16,23 +35,23 @@ const OurServiceSection = () => {
       className={`${styles.section} ${isVisible ? styles.visible : ""}`}
     >
       <div className={styles.container}>
-        <h2 className={styles.title}>Our Services</h2>
+        <h2 className={styles.title}>{texts[language].title}</h2>
         <div className={styles.iconRow}>
           <div className={styles.iconBlock}>
             <img src={TruckSalesIcon} alt="Truck Sales" />
-            <p>Truck Sales</p>
+            <p>{texts[language].sales}</p>
           </div>
           <div className={styles.iconBlock}>
             <img src={ImportExportIcon} alt="Import/Export" />
-            <p>Import/Export</p>
+            <p>{texts[language].importExport}</p>
           </div>
           <div className={styles.iconBlock}>
             <img src={UsedTruckIcon} alt="Used Truck Purchase" />
-            <p>Used Truck<br />Purchase</p>
+            <p dangerouslySetInnerHTML={{ __html: texts[language].used }} />
           </div>
           <div className={styles.iconBlock}>
             <img src={SparePartsIcon} alt="Spare Parts & Engine" />
-            <p>Spare Parts<br />& Engine</p>
+            <p dangerouslySetInnerHTML={{ __html: texts[language].parts }} />
           </div>
         </div>
       </div>

--- a/src/sections/MainPage/PurchaseSaleSection.jsx
+++ b/src/sections/MainPage/PurchaseSaleSection.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import styles from "./PurchaseSaleSection.module.css";
 import { Link } from "react-router-dom";
 import { useInView } from "../../hooks/useInView";
+import { useLanguage } from "../../context/LanguageContext";
 
 import truckImage from "../../assets/images/MainPage/Vehicles.png";
 import equipmentImage from "../../assets/images/MainPage/EquipmentParts.png";
@@ -11,31 +12,53 @@ import TruckIcon from "../../assets/icons/Vehicles.svg";
 import EquipmentIcon from "../../assets/icons/EquipmentParts.svg";
 import TiresIcon from "../../assets/icons/Tires.svg";
 
-const data = [
-  {
-    title: "Vehicles",
-    description:
-      "Cars, delivery vans, trucks, semi-trucks, and coaches — available new and used",
-    icon: TruckIcon,
-    image: truckImage,
-  },
-  {
-    title: "Equipment & Parts",
-    description:
-      "Construction machinery, agricultural equipment, trailers, and engines. Engine and spare parts available.",
-    icon: EquipmentIcon,
-    image: equipmentImage,
-  },
-  {
-    title: "Tires",
-    description:
-      "New and used tires for passenger cars, light commercial vehicles, and heavy-duty vehicles. New and used tires also available for paycars",
-    icon: TiresIcon,
-    image: tiresImage,
-  },
-];
+const data = {
+  pl: [
+    {
+      title: "Pojazdy",
+      description: "Samochody, dostawcze, ciężarówki, ciągniki i autobusy — nowe i używane",
+      icon: TruckIcon,
+      image: truckImage,
+    },
+    {
+      title: "Sprzęt i części",
+      description: "Maszyny budowlane, sprzęt rolniczy, naczepy oraz silniki. Dostępne części zamienne.",
+      icon: EquipmentIcon,
+      image: equipmentImage,
+    },
+    {
+      title: "Opony",
+      description: "Nowe i używane opony do samochodów osobowych, dostawczych i ciężarowych.",
+      icon: TiresIcon,
+      image: tiresImage,
+    },
+  ],
+  en: [
+    {
+      title: "Vehicles",
+      description: "Cars, delivery vans, trucks, semi-trucks, and coaches — available new and used",
+      icon: TruckIcon,
+      image: truckImage,
+    },
+    {
+      title: "Equipment & Parts",
+      description: "Construction machinery, agricultural equipment, trailers, and engines. Engine and spare parts available.",
+      icon: EquipmentIcon,
+      image: equipmentImage,
+    },
+    {
+      title: "Tires",
+      description: "New and used tires for passenger cars, light commercial vehicles, and heavy-duty vehicles.",
+      icon: TiresIcon,
+      image: tiresImage,
+    },
+  ],
+};
+
+const buttons = { pl: { purchase: "Zakup", sale: "Sprzedaż" }, en: { purchase: "Purchase", sale: "Sale" } };
 
 const PurchaseSaleSection = () => {
+  const { language } = useLanguage();
   const [sectionRef, sectionVisible] = useInView(0.2);
 
   return (
@@ -47,7 +70,7 @@ const PurchaseSaleSection = () => {
         }}
 >
       <div className={styles.container}>
-        {data.map((item, index) => {
+        {data[language].map((item, index) => {
           const [cardRef, isVisible] = useInView(0.3);
 
           return (
@@ -68,8 +91,8 @@ const PurchaseSaleSection = () => {
                 <div className={styles.imageBlock}>
                   <img src={item.image} alt={item.title} className={styles.image} />
                   <div className={styles.buttons}>
-                    <Link to="/purchase" className={styles.btn}>Purchase</Link>
-                    <Link to="/sale" className={styles.btn}>Sale</Link>
+                    <Link to="/purchase" className={styles.btn}>{buttons[language].purchase}</Link>
+                    <Link to="/sale" className={styles.btn}>{buttons[language].sale}</Link>
                   </div>
                 </div>
               </div>

--- a/src/sections/PurchaseItemPage/PurchaseItemHeader.jsx
+++ b/src/sections/PurchaseItemPage/PurchaseItemHeader.jsx
@@ -1,11 +1,13 @@
 import React from "react";
 import styles from "./PurchaseItemHeader.module.css";
+import { useLanguage } from "../../context/LanguageContext";
 
-const PurchaseItemHeader = ({ title, mainImage, specs, description }) => {
+const PurchaseItemHeader = ({ titlePl, titleEn, title, mainImage, specs, descriptionPl, descriptionEn }) => {
+  const { language } = useLanguage();
   return (
     <section className={styles.wrapper}>
       <div className={styles.container}>
-        <h1 className={styles.title}>{title}</h1>
+        <h1 className={styles.title}>{language === 'pl' ? (titlePl || title) : (titleEn || title)}</h1>
         <div className={styles.content}>
           <div className={styles.imageBlock}>
             {mainImage ? (
@@ -15,7 +17,7 @@ const PurchaseItemHeader = ({ title, mainImage, specs, description }) => {
             )}
           </div>
           <div className={styles.infoBlock}>
-            <h3>Specyfikacja</h3>
+            <h3>{language === 'pl' ? 'Specyfikacja' : 'Specifications'}</h3>
             <table className={styles.table}>
               <tbody>
                 {specs.map((s, i) => (
@@ -27,8 +29,8 @@ const PurchaseItemHeader = ({ title, mainImage, specs, description }) => {
               </tbody>
             </table>
 
-            <h3 className={styles.descTitle}>Opis</h3>
-            <p className={styles.description}>{description}</p>
+            <h3 className={styles.descTitle}>{language === 'pl' ? 'Opis' : 'Description'}</h3>
+            <p className={styles.description}>{language === 'pl' ? (descriptionPl || descriptionEn) : (descriptionEn || descriptionPl)}</p>
           </div>
         </div>
       </div>

--- a/src/sections/PurchasePage/PurchaseCard.jsx
+++ b/src/sections/PurchasePage/PurchaseCard.jsx
@@ -1,15 +1,17 @@
 import React from "react";
 import styles from "./PurchaseCard.module.css";
 import { Link } from "react-router-dom";
+import { useLanguage } from "../../context/LanguageContext";
 
-const PurchaseCard = ({ id, title, year, status, mainImage, image }) => {
+const PurchaseCard = ({ id, titlePl, titleEn, title, year, status, mainImage, image }) => {
+  const { language } = useLanguage();
   const isAvailable = status === "poszukiwane" || status === "available";
 
   return (
     <Link to={`/purchase/${id}`} className={styles.card}>
-      <img src={mainImage || image} alt={title} className={styles.image} />
+      <img src={mainImage || image} alt={titlePl || titleEn || title} className={styles.image} />
       <div className={styles.details}>
-        <h3 className={styles.title}>{title}</h3>
+        <h3 className={styles.title}>{language === 'pl' ? (titlePl || title) : (titleEn || title)}</h3>
         <p className={styles.year}>{year}</p>
         <span
           className={`${styles.status} ${

--- a/src/sections/SalePage/ItemCard.jsx
+++ b/src/sections/SalePage/ItemCard.jsx
@@ -1,9 +1,11 @@
 import React from "react";
 import styles from "./ItemCard.module.css";
 import { Link } from "react-router-dom";
+import { useLanguage } from "../../context/LanguageContext";
 
 const ItemCard = ({ item }) => {
-  const { id, title, year, status, mainImage } = item;
+  const { language } = useLanguage();
+  const { id, titlePl, titleEn, title, year, status, mainImage } = item;
 
   return (
     <div className={styles.card}>
@@ -18,10 +20,10 @@ const ItemCard = ({ item }) => {
         </span>
       </div>
       <div className={styles.info}>
-        <h3 className={styles.title}>{title}</h3>
+        <h3 className={styles.title}>{language === 'pl' ? (titlePl || title) : (titleEn || title)}</h3>
         <p className={styles.year}>{year}</p>
         <Link to={`/sale/${id}`} className={styles.button}>
-          View Details
+          {language === 'pl' ? 'Szczegóły' : 'View Details'}
         </Link>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add LanguageContext and wrap app
- implement language toggle and translations for navbar and all main sections
- support bilingual fields in admin forms and item pages
- update item cards and headers to display selected language

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842ce26c8688323a17625ce86a3c6e6